### PR TITLE
feat: add media attachment

### DIFF
--- a/src/main/java/com/plux/distribution/Main.java
+++ b/src/main/java/com/plux/distribution/Main.java
@@ -219,7 +219,8 @@ public class Main {
         schedulerRunner.start();
         log.info("Session scheduler successfully started");
 
-        var tgHandler = new TelegramHandler(interactionDeliveryService, chatService, tgMessageLinker, tgChatLinker);
+        var tgHandler = new TelegramHandler(tgClient, interactionDeliveryService, chatService, mediaService,
+                tgMessageLinker, tgChatLinker);
 
         AnnotationConfigWebApplicationContext springContext = new AnnotationConfigWebApplicationContext();
 

--- a/src/main/java/com/plux/distribution/Main.java
+++ b/src/main/java/com/plux/distribution/Main.java
@@ -142,17 +142,6 @@ public class Main {
         var scheduleSettingsRepo = new DbScheduleSettingsRepository(hibernateConfig.getSessionFactory());
         var sessionInteractionsRepo = new DbSessionInteractionsRepository(hibernateConfig.getSessionFactory());
 
-        var tgChatLinker = new DbTgChatLinker(hibernateConfig.getSessionFactory());
-        var tgMessageLinker = new DbTgMessageLinker(hibernateConfig.getSessionFactory());
-        var tgClient = new OkHttpTelegramClient(botToken);
-
-        var sender = new TelegramInteractionSender(tgClient, tgChatLinker, tgMessageLinker);
-        var executor = new TelegramActionExecutor(tgClient, tgChatLinker, tgMessageLinker);
-
-        var interactionService = new InteractionService(interactionsRepo);
-        var interactionDeliveryService = new InteractionDeliveryService(interactionsRepo, sender);
-        var executeActionService = new ExecuteActionService(executor);
-
         var chatService = new ChatService(chatRepo, chatRepo, chatRepo);
         var userService = new UserService(userRepo);
 
@@ -165,6 +154,17 @@ public class Main {
         var mediaFileStorageService = new StorageService(mediaFileStorage, Duration.ofMinutes(1));
         var mediaService = new MediaStorageService(mediaFileStorageService, mediaFileStorageService,
                 mediaFileStorageService, mediaFileStorageService, mediaRepo);
+
+        var tgChatLinker = new DbTgChatLinker(hibernateConfig.getSessionFactory());
+        var tgMessageLinker = new DbTgMessageLinker(hibernateConfig.getSessionFactory());
+        var tgClient = new OkHttpTelegramClient(botToken);
+
+        var sender = new TelegramInteractionSender(tgClient, tgChatLinker, tgMessageLinker, mediaService);
+        var executor = new TelegramActionExecutor(tgClient, tgChatLinker, tgMessageLinker);
+
+        var interactionService = new InteractionService(interactionsRepo);
+        var interactionDeliveryService = new InteractionDeliveryService(interactionsRepo, sender);
+        var executeActionService = new ExecuteActionService(executor);
 
         var integrationService = new IntegrationService(integrationRepo);
         var findInteractionSourceService = new FindInteractionSourceService(serviceSendingRepo);

--- a/src/main/java/com/plux/distribution/core/interaction/domain/content/MessageAttachment.java
+++ b/src/main/java/com/plux/distribution/core/interaction/domain/content/MessageAttachment.java
@@ -1,8 +1,14 @@
 package com.plux.distribution.core.interaction.domain.content;
 
+import com.plux.distribution.core.mediastorage.domain.MediaId;
 import org.jetbrains.annotations.NotNull;
 
-public sealed interface MessageAttachment permits MessageAttachment.ButtonAttachment {
+public sealed interface MessageAttachment {
 
     record ButtonAttachment(@NotNull String text, @NotNull String tag) implements MessageAttachment {}
+
+    record MediaAttachment(@NotNull MediaId mediaId, @NotNull DisplayType displayType) implements MessageAttachment {
+
+        public enum DisplayType {PHOTO, DOCUMENT}
+    }
 }

--- a/src/main/java/com/plux/distribution/infrastructure/api/mediastorage/MediaStorageController.java
+++ b/src/main/java/com/plux/distribution/infrastructure/api/mediastorage/MediaStorageController.java
@@ -69,10 +69,15 @@ public class MediaStorageController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Content-Type is required");
         }
 
+        String filename = file.getOriginalFilename();
+        if (filename == null || filename.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filename is required");
+        }
+
         MediaId mediaId = crudMediaUseCase.upload(
                 file.getInputStream(),
-                file.getContentType(),
-                file.getName(),
+                contentType,
+                filename,
                 file.getSize(),
                 scope);
         return ResponseEntity.status(HttpStatus.CREATED).body(UploadMediaResponse.of(mediaId));

--- a/src/main/java/com/plux/distribution/infrastructure/api/message/request/attachment/MediaAttachmentRequest.java
+++ b/src/main/java/com/plux/distribution/infrastructure/api/message/request/attachment/MediaAttachmentRequest.java
@@ -1,0 +1,35 @@
+package com.plux.distribution.infrastructure.api.message.request.attachment;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment.DisplayType;
+import com.plux.distribution.core.mediastorage.domain.MediaId;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record MediaAttachmentRequest(
+        @NotNull UUID mediaId,
+        @NotNull DisplayTypeRequest displayType
+) implements MessageAttachmentRequest {
+
+    @Override
+    public MessageAttachment toModel() {
+        return new MediaAttachment(
+                new MediaId(mediaId),
+                displayType.toDomain()
+        );
+    }
+
+    enum DisplayTypeRequest {
+        @JsonProperty("photo") PHOTO,
+        @JsonProperty("document") DOCUMENT;
+
+        public DisplayType toDomain() {
+            return switch (this) {
+                case PHOTO -> DisplayType.PHOTO;
+                case DOCUMENT -> DisplayType.DOCUMENT;
+            };
+        }
+    }
+}

--- a/src/main/java/com/plux/distribution/infrastructure/api/message/request/attachment/MessageAttachmentRequest.java
+++ b/src/main/java/com/plux/distribution/infrastructure/api/message/request/attachment/MessageAttachmentRequest.java
@@ -17,13 +17,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 )
 @JsonSubTypes({
         @Type(value = ButtonAttachmentRequest.class, name = "button"),
+        @Type(value = MediaAttachmentRequest.class, name = "media"),
 })
 @Schema(
         discriminatorMapping = {
                 @DiscriminatorMapping(value = "button", schema = ButtonAttachmentRequest.class),
+                @DiscriminatorMapping(value = "media", schema = MediaAttachmentRequest.class),
         }
 )
-public sealed interface MessageAttachmentRequest permits ButtonAttachmentRequest {
+public sealed interface MessageAttachmentRequest permits ButtonAttachmentRequest, MediaAttachmentRequest {
 
     MessageAttachment toModel();
 }

--- a/src/main/java/com/plux/distribution/infrastructure/notifier/view/interaction/MessageAttachmentView.java
+++ b/src/main/java/com/plux/distribution/infrastructure/notifier/view/interaction/MessageAttachmentView.java
@@ -1,11 +1,17 @@
 package com.plux.distribution.infrastructure.notifier.view.interaction;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.plux.distribution.core.interaction.domain.content.MessageAttachment;
 import com.plux.distribution.core.interaction.domain.content.MessageAttachment.ButtonAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment.DisplayType;
+import com.plux.distribution.infrastructure.notifier.view.interaction.MessageAttachmentView.MediaAttachmentView.DisplayTypeView;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 
 @JsonTypeInfo(
@@ -15,22 +21,40 @@ import org.jetbrains.annotations.NotNull;
 )
 @JsonSubTypes({
         @JsonSubTypes.Type(value = MessageAttachmentView.ButtonAttachmentView.class, name = "button"),
+        @JsonSubTypes.Type(value = MessageAttachmentView.MediaAttachmentView.class, name = "media"),
 })
 @Schema(
         discriminatorMapping = {
-                @DiscriminatorMapping(schema = MessageAttachmentView.ButtonAttachmentView.class, value = "button")
+                @DiscriminatorMapping(schema = MessageAttachmentView.ButtonAttachmentView.class, value = "button"),
+                @DiscriminatorMapping(schema = MessageAttachmentView.MediaAttachmentView.class, value = "media")
         }
 )
-public sealed interface MessageAttachmentView permits MessageAttachmentView.ButtonAttachmentView {
+public sealed interface MessageAttachmentView {
 
     static @NotNull MessageAttachmentView create(@NotNull MessageAttachment attachment) {
         return switch (attachment) {
             case ButtonAttachment a -> new ButtonAttachmentView(a.text(), a.tag());
+            case MediaAttachment a ->
+                    new MediaAttachmentView(a.mediaId().value(), DisplayTypeView.from(a.displayType()));
         };
     }
 
-    record ButtonAttachmentView(@NotNull String text, @NotNull String tag) implements MessageAttachmentView {
+    record ButtonAttachmentView(@NotNull String text, @NotNull String tag) implements MessageAttachmentView {}
 
+    record MediaAttachmentView(@NotNull UUID mediaId, @NotNull DisplayTypeView displayType) implements
+            MessageAttachmentView {
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        enum DisplayTypeView {
+            @JsonProperty("photo") PHOTO,
+            @JsonProperty("document") DOCUMENT;
+
+            public static DisplayTypeView from(@NotNull DisplayType domainType) {
+                return switch (domainType) {
+                    case PHOTO -> PHOTO;
+                    case DOCUMENT -> DOCUMENT;
+                };
+            }
+        }
     }
-
 }

--- a/src/main/java/com/plux/distribution/infrastructure/persistence/entity/interaction/attachment/AttachmentEntity.java
+++ b/src/main/java/com/plux/distribution/infrastructure/persistence/entity/interaction/attachment/AttachmentEntity.java
@@ -2,6 +2,7 @@ package com.plux.distribution.infrastructure.persistence.entity.interaction.atta
 
 import com.plux.distribution.core.interaction.domain.content.MessageAttachment;
 import com.plux.distribution.core.interaction.domain.content.MessageAttachment.ButtonAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.Entity;
@@ -26,6 +27,7 @@ public abstract class AttachmentEntity {
     public static AttachmentEntity fromModel(MessageAttachment model) {
         return switch (model) {
             case ButtonAttachment a -> new ButtonAttachmentEntity(a.text(), a.tag());
+            case MediaAttachment a -> new MediaAttachmentEntity(a.mediaId().value(), a.displayType());
         };
     }
 

--- a/src/main/java/com/plux/distribution/infrastructure/persistence/entity/interaction/attachment/MediaAttachmentEntity.java
+++ b/src/main/java/com/plux/distribution/infrastructure/persistence/entity/interaction/attachment/MediaAttachmentEntity.java
@@ -1,0 +1,35 @@
+package com.plux.distribution.infrastructure.persistence.entity.interaction.attachment;
+
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment.DisplayType;
+import com.plux.distribution.core.mediastorage.domain.MediaId;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.util.UUID;
+
+@Entity
+@DiscriminatorValue("MEDIA")
+public class MediaAttachmentEntity extends AttachmentEntity {
+
+    private UUID mediaId;
+
+    @Enumerated(EnumType.STRING)
+    private DisplayType displayType;  // TODO: может быть лучше добавить еще один DisplayType
+
+    public MediaAttachmentEntity(UUID mediaId, DisplayType displayType) {
+        this.mediaId = mediaId;
+        this.displayType = displayType;
+    }
+
+    public MediaAttachmentEntity() {
+
+    }
+
+    @Override
+    public MessageAttachment toModel() {
+        return new MediaAttachment(new MediaId(mediaId), displayType);
+    }
+}

--- a/src/main/java/com/plux/distribution/infrastructure/telegram/TelegramHandler.java
+++ b/src/main/java/com/plux/distribution/infrastructure/telegram/TelegramHandler.java
@@ -7,32 +7,51 @@ import com.plux.distribution.core.interaction.domain.Participant.BotParticipant;
 import com.plux.distribution.core.interaction.domain.Participant.ChatParticipant;
 import com.plux.distribution.core.interaction.domain.content.ButtonClickContent;
 import com.plux.distribution.core.interaction.domain.content.InteractionContent;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment.DisplayType;
 import com.plux.distribution.core.interaction.domain.content.ReplyMessageContent;
 import com.plux.distribution.core.interaction.domain.content.SimpleMessageContent;
+import com.plux.distribution.core.mediastorage.application.port.in.UploadMediaUseCase;
+import com.plux.distribution.core.mediastorage.domain.MediaId;
 import com.plux.distribution.infrastructure.telegram.port.TgChatLinker;
 import com.plux.distribution.infrastructure.telegram.port.TgMessageGlobalId;
 import com.plux.distribution.infrastructure.telegram.port.TgMessageLinker;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
+import org.telegram.telegrambots.meta.api.methods.GetFile;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Document;
+import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.photo.PhotoSize;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 public class TelegramHandler implements LongPollingSingleThreadUpdateConsumer {
 
+    private final @NotNull TelegramClient telegramClient;
     private final @NotNull InteractionDeliveryUseCase interactionDeliveryUseCase;
     private final @NotNull CreateChatUseCase createChatUseCase;
+    private final @NotNull UploadMediaUseCase uploadMediaUseCase;
     private final @NotNull TgMessageLinker tgMessageLinker;
     private final @NotNull TgChatLinker tgChatLinker;
 
-    public TelegramHandler(@NotNull InteractionDeliveryUseCase interactionDeliveryUseCase,
-            @NotNull CreateChatUseCase createChatUseCase,
+    public TelegramHandler(@NotNull TelegramClient telegramClient,
+            @NotNull InteractionDeliveryUseCase interactionDeliveryUseCase,
+            @NotNull CreateChatUseCase createChatUseCase, @NotNull UploadMediaUseCase uploadMediaUseCase,
             @NotNull TgMessageLinker tgMessageLinker, @NotNull TgChatLinker tgChatLinker) {
-
+        this.telegramClient = telegramClient;
         this.interactionDeliveryUseCase = interactionDeliveryUseCase;
         this.createChatUseCase = createChatUseCase;
+        this.uploadMediaUseCase = uploadMediaUseCase;
         this.tgMessageLinker = tgMessageLinker;
         this.tgChatLinker = tgChatLinker;
     }
@@ -61,9 +80,13 @@ public class TelegramHandler implements LongPollingSingleThreadUpdateConsumer {
             tgChatLinker.link(chatId, message.getChatId());
         }
 
+        List<MessageAttachment> attachments = new ArrayList<>();
+        attachments.addAll(processPhotos(message));
+        attachments.addAll(processDocument(message));
+
         InteractionContent content = new SimpleMessageContent(
                 Optional.ofNullable(message.getText()).orElse(""),
-                List.of()
+                attachments
         );
 
         if (message.isReply()) {
@@ -86,6 +109,61 @@ public class TelegramHandler implements LongPollingSingleThreadUpdateConsumer {
         var messageId = interactionDeliveryUseCase.deliver(command);
 
         tgMessageLinker.link(messageId, new TgMessageGlobalId(message.getMessageId(), message.getChatId()));
+    }
+
+    private List<MessageAttachment> processPhotos(Message message) {
+        if (message.getPhoto() == null || message.getPhoto().isEmpty()) {
+            return List.of();
+        }
+
+        var largestPhoto = message.getPhoto().stream()
+                .max(Comparator.comparingInt(PhotoSize::getFileSize))
+                .orElseThrow();
+
+        MediaId mediaId = downloadAndUpload(
+                largestPhoto.getFileId(),
+                "image/jpeg",
+                largestPhoto.getFileSize()
+        );
+
+        return List.of(new MediaAttachment(mediaId, DisplayType.PHOTO));
+    }
+
+    private List<MessageAttachment> processDocument(Message message) {
+        if (!message.hasDocument()) {
+            return List.of();
+        }
+
+        Document doc = message.getDocument();
+
+        MediaId mediaId = downloadAndUpload(
+                doc.getFileId(),
+                Optional.ofNullable(doc.getMimeType()).orElse("application/octet-stream"),
+                doc.getFileSize()
+        );
+
+        return List.of(new MediaAttachment(mediaId, DisplayType.DOCUMENT));
+    }
+
+    private MediaId downloadAndUpload(String fileId, String mimeType, long fileSize) {
+        try {
+            File file = telegramClient.execute(new GetFile(fileId));
+
+            try (InputStream inputStream = telegramClient.downloadFileAsStream(file)) {
+                System.out.println(file.getFilePath());
+                return uploadMediaUseCase.upload(
+                        inputStream,
+                        mimeType,
+                        file.getFilePath(),
+                        fileSize,
+                        "in_chat"
+                );
+            }
+
+        } catch (TelegramApiException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
     private void processCallback(CallbackQuery callbackQuery) {

--- a/src/main/java/com/plux/distribution/infrastructure/telegram/sender/RenderingContext.java
+++ b/src/main/java/com/plux/distribution/infrastructure/telegram/sender/RenderingContext.java
@@ -1,19 +1,22 @@
 package com.plux.distribution.infrastructure.telegram.sender;
 
-import org.jetbrains.annotations.NotNull;
-import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.ButtonAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 class RenderingContext {
 
-    @NotNull
-    final SendMessage.SendMessageBuilder<?, ?> sendMessageBuilder;
-    @NotNull
-    final InlineKeyboardMarkup.InlineKeyboardMarkupBuilder<?, ?> inlineKeyboardMarkupBuilder;
-    boolean hasButtons = false;
+    final long tgChatId;
 
-    RenderingContext() {
-        sendMessageBuilder = SendMessage.builder();
-        inlineKeyboardMarkupBuilder = InlineKeyboardMarkup.builder();
+    @Nullable String text;
+    @Nullable Integer replyToMessageId;
+
+    final List<ButtonAttachment> buttons = new ArrayList<>();
+    final List<MediaAttachment> mediaAttachments = new ArrayList<>();
+
+    RenderingContext(long tgChatId) {
+        this.tgChatId = tgChatId;
     }
 }

--- a/src/main/java/com/plux/distribution/infrastructure/telegram/sender/TelegramInteractionSender.java
+++ b/src/main/java/com/plux/distribution/infrastructure/telegram/sender/TelegramInteractionSender.java
@@ -8,12 +8,29 @@ import com.plux.distribution.core.interaction.domain.Participant.ChatParticipant
 import com.plux.distribution.core.interaction.domain.content.ButtonClickContent;
 import com.plux.distribution.core.interaction.domain.content.InteractionContent;
 import com.plux.distribution.core.interaction.domain.content.MessageAttachment.ButtonAttachment;
+import com.plux.distribution.core.interaction.domain.content.MessageAttachment.MediaAttachment;
 import com.plux.distribution.core.interaction.domain.content.ReplyMessageContent;
 import com.plux.distribution.core.interaction.domain.content.SimpleMessageContent;
+import com.plux.distribution.core.mediastorage.application.dto.StoredMedia;
+import com.plux.distribution.core.mediastorage.application.exception.MediaNotFoundException;
+import com.plux.distribution.core.mediastorage.application.port.in.DownloadMediaUseCase;
 import com.plux.distribution.infrastructure.telegram.port.TgChatLinker;
 import com.plux.distribution.infrastructure.telegram.port.TgMessageGlobalId;
 import com.plux.distribution.infrastructure.telegram.port.TgMessageLinker;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
+import org.telegram.telegrambots.meta.api.methods.send.SendDocument;
+import org.telegram.telegrambots.meta.api.methods.send.SendMediaGroup;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+import org.telegram.telegrambots.meta.api.objects.media.InputMedia;
+import org.telegram.telegrambots.meta.api.objects.media.InputMediaDocument;
+import org.telegram.telegrambots.meta.api.objects.media.InputMediaPhoto;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -24,37 +41,34 @@ public class TelegramInteractionSender implements InteractionSenderPort {
     private final @NotNull TelegramClient client;
     private final @NotNull TgChatLinker tgChatLinker;
     private final @NotNull TgMessageLinker tgMessageLinker;
+    private final @NotNull DownloadMediaUseCase downloadMediaUseCase;
 
 
     public TelegramInteractionSender(@NotNull TelegramClient client,
-            @NotNull TgChatLinker tgChatLinker, @NotNull TgMessageLinker tgMessageLinker) {
+            @NotNull TgChatLinker tgChatLinker, @NotNull TgMessageLinker tgMessageLinker,
+            @NotNull DownloadMediaUseCase downloadMediaUseCase) {
         this.client = client;
         this.tgChatLinker = tgChatLinker;
         this.tgMessageLinker = tgMessageLinker;
+        this.downloadMediaUseCase = downloadMediaUseCase;
     }
 
     @Override
     public void send(@NotNull InteractionId interactionId, @NotNull Participant recipient,
             @NotNull InteractionContent interactionContent) {
-        var context = new RenderingContext();
-        context.sendMessageBuilder.parseMode("Markdown");
-
         if (!(recipient instanceof ChatParticipant(ChatId chatId))) {
             throw new IllegalArgumentException("Not chat participants is not allowed here");
         }
 
-        var tgId = tgChatLinker.getTgChatId(chatId);
+        var tgChatId = tgChatLinker.getTgChatId(chatId);
 
-        context.sendMessageBuilder.chatId(tgId);
+        var context = new RenderingContext(tgChatId);
 
         constructContent(context, interactionContent);
 
-        var tgMessage = context.sendMessageBuilder.build();
-
         try {
-            var res = client.execute(tgMessage);
-
-            tgMessageLinker.link(interactionId, new TgMessageGlobalId(res.getMessageId(), tgId));
+            Message result = sendMessage(context);
+            tgMessageLinker.link(interactionId, new TgMessageGlobalId(result.getMessageId(), tgChatId));
         } catch (TelegramApiException e) {
             throw new RuntimeException(e);
         }
@@ -63,36 +77,153 @@ public class TelegramInteractionSender implements InteractionSenderPort {
     private void constructContent(@NotNull RenderingContext context, InteractionContent content) {
         switch (content) {
             case SimpleMessageContent c -> {
-                context.sendMessageBuilder.text(c.text());
+                context.text = c.text();
 
                 for (var attachment : c.attachments()) {
                     switch (attachment) {
-                        case ButtonAttachment a -> {
-                            context.inlineKeyboardMarkupBuilder.keyboardRow(
-                                    new InlineKeyboardRow(
-                                            InlineKeyboardButton
-                                                    .builder()
-                                                    .text(a.text())
-                                                    .callbackData(a.tag())
-                                                    .build()
-                                    )
-                            );
-                            context.hasButtons = true;
-                        }
-                    }
-
-                    if (context.hasButtons) {
-                        context.sendMessageBuilder.replyMarkup(context.inlineKeyboardMarkupBuilder.build());
+                        case ButtonAttachment a -> context.buttons.add(a);
+                        case MediaAttachment a -> context.mediaAttachments.add(a);
                     }
                 }
             }
             case ReplyMessageContent c -> {
                 var tgReplyMessageId = tgMessageLinker.getTgMessageId(c.replyTo());
-                context.sendMessageBuilder.replyToMessageId(tgReplyMessageId.messageId());
-
+                context.replyToMessageId = tgReplyMessageId.messageId();
                 constructContent(context, c.original());
             }
             case ButtonClickContent _ -> throw new UnsupportedOperationException();
+        }
+    }
+
+    private Message sendMessage(RenderingContext context) throws TelegramApiException {
+        if (context.mediaAttachments.isEmpty()) {
+            return sendTextMessage(context);
+        } else if (context.mediaAttachments.size() == 1) {
+            return sendSingleMedia(context);
+        } else {
+            return sendMediaGroup(context);
+        }
+    }
+
+    private Message sendTextMessage(RenderingContext context) throws TelegramApiException {
+        var builder = SendMessage.builder()
+                .chatId(context.tgChatId)
+                .text(Objects.requireNonNull(context.text))
+                .parseMode("Markdown");
+
+        if (context.replyToMessageId != null) {
+            builder.replyToMessageId(context.replyToMessageId);
+        }
+
+        if (!context.buttons.isEmpty()) {
+            builder.replyMarkup(buildKeyboard(context.buttons));
+        }
+
+        return client.execute(builder.build());
+    }
+
+    private Message sendSingleMedia(RenderingContext context) throws TelegramApiException {
+        var media = context.mediaAttachments.getFirst();
+        var storedFile = getMediaFile(media);
+
+        return switch (media.displayType()) {
+            case PHOTO -> {
+                var builder = SendPhoto.builder()
+                        .chatId(context.tgChatId)
+                        .photo(new InputFile(storedFile.file().data(), storedFile.metadata().filename()))
+                        .caption(context.text)
+                        .parseMode("Markdown");
+
+                if (context.replyToMessageId != null) {
+                    builder.replyToMessageId(context.replyToMessageId);
+                }
+
+                if (!context.buttons.isEmpty()) {
+                    builder.replyMarkup(buildKeyboard(context.buttons));
+                }
+
+                yield client.execute(builder.build());
+            }
+            case DOCUMENT -> {
+                var builder = SendDocument.builder()
+                        .chatId(context.tgChatId)
+                        .document(new InputFile(storedFile.file().data(), storedFile.metadata().filename()))
+                        .caption(context.text)
+                        .parseMode("Markdown");
+
+                if (context.replyToMessageId != null) {
+                    builder.replyToMessageId(context.replyToMessageId);
+                }
+
+                if (!context.buttons.isEmpty()) {
+                    builder.replyMarkup(buildKeyboard(context.buttons));
+                }
+
+                yield client.execute(builder.build());
+            }
+        };
+    }
+
+    private Message sendMediaGroup(RenderingContext context) throws TelegramApiException {
+        List<InputMedia> inputMediaList = new ArrayList<>();
+
+        for (int i = 0; i < context.mediaAttachments.size(); i++) {
+            var attachment = context.mediaAttachments.get(i);
+            var storedFile = getMediaFile(attachment);
+
+            InputMedia inputMedia = switch (attachment.displayType()) {
+                case PHOTO -> InputMediaPhoto.builder()
+                        .media(storedFile.file().data(), storedFile.metadata().filename())
+                        .build();
+                case DOCUMENT -> InputMediaDocument.builder()
+                        .media(storedFile.file().data(), storedFile.metadata().filename())
+                        .build();
+            };
+
+            if (i == 0 && context.text != null && !context.text.isBlank()) {
+                inputMedia.setCaption(context.text);
+                inputMedia.setParseMode("Markdown");
+            }
+
+            inputMediaList.add(inputMedia);
+        }
+
+        var builder = SendMediaGroup.builder()
+                .chatId(context.tgChatId)
+                .medias(inputMediaList);
+
+        if (context.replyToMessageId != null) {
+            builder.replyToMessageId(context.replyToMessageId);
+        }
+
+        if (!context.buttons.isEmpty()) {
+            builder.replyMarkup(buildKeyboard(context.buttons));
+        }
+
+        List<Message> messages = client.execute(builder.build());
+        return messages.getFirst();
+    }
+
+    private InlineKeyboardMarkup buildKeyboard(List<ButtonAttachment> buttons) {
+        var rows = buttons.stream()
+                .map(b -> new InlineKeyboardRow(
+                        InlineKeyboardButton.builder()
+                                .text(b.text())
+                                .callbackData(b.tag())
+                                .build()
+                ))
+                .toList();
+
+        return InlineKeyboardMarkup.builder()
+                .keyboard(rows)
+                .build();
+    }
+
+    private StoredMedia getMediaFile(MediaAttachment attachment) {
+        try {
+            return downloadMediaUseCase.download(attachment.mediaId());
+        } catch (MediaNotFoundException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/resources/db/changelog/2026/01/12-01-add-media-attachment.xml
+++ b/src/main/resources/db/changelog/2026/01/12-01-add-media-attachment.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1768238230774-add-columns" author="enard">
+        <addColumn tableName="attachments">
+            <column name="display_type" type="VARCHAR(255)"/>
+            <column name="media_id" type="UUID"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -17,4 +17,5 @@
     <include file="db/changelog/2025/12/01-01-refactor-messages.xml"/>
     <include file="db/changelog/2025/12/02-01-refactor-feedback.xml"/>
     <include file="/db/changelog/2026/01/11-01-add-media.xml"/>
+    <include file="db/changelog/2026/01/12-01-add-media-attachment.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Изменения

### Новая функциональность
- Добавлена полная поддержка медиа вложений в сообщениях Telegram бота
- Реализована возможность отправки фото и документов через бота
- Добавлена обработка входящих медиа сообщений от пользователей
- Поддержка групповой отправки медиафайлов (до 10 файлов одновременно)

### Доменная модель
#### Расширение MessageAttachment
- Добавлен новый тип вложения `MediaAttachment` с поддержкой:
  - `MediaId` - ссылка на медиафайл в хранилище
  - `DisplayType` - тип отображения (PHOTO или DOCUMENT)

### API расширения
#### Новые request DTO
- `MediaAttachmentRequest` - для создания медиа вложений через API
- Поддержка типов отображения через JSON: `"photo"` и `"document"`

### Обработка входящих сообщений
#### TelegramHandler обновления
- Добавлена обработка фото сообщений от пользователей
- Автоматическая загрузка медиафайлов в хранилище при получении
- Создание соответствующих `MediaAttachment` для дальнейшей обработки

### Отправка сообщений
#### TelegramInteractionSender расширения
- Добавлена поддержка отправки медиа через `SendPhoto` и `SendDocument`
- Реализована групповая отправка через `SendMediaGroup` для нескольких медиафайлов
- Добавлена валидация возможности отправки медиа в зависимости от типа контента
- Интеграция с `DownloadMediaUseCase` для получения файлов из хранилища

### Технические детали
- **Ограничения**: максимум 10 медиафайлов в группе (ограничение Telegram API)

### Конфигурация
- Обновлена инициализация в `Main.java` для передачи `UploadMediaUseCase` в `TelegramHandler`
- Обновлен `TelegramInteractionSender` с зависимостью от `DownloadMediaUseCase`
